### PR TITLE
Added check to ensure transfer adheres to token decimal support

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -85,6 +85,9 @@ async function issueToken(
       }
       const tokenData = await getTokenData(currencyId, provider);
       tokenAmount = tokenAmount * (Math.pow(10,tokenData.decimal));
+      if (tokenAmount < 1) {
+        throw new Error(`Invalid token amount, max supported decimal for this token is ${tokenData.decimal}`);
+      }
       const tx = provider.tx.tokens.transfer(receiverAccountID, currencyId, tokenAmount);
       let nonce = await provider.rpc.system.accountNextIndex(senderAccountKeyPair.address);
       let signedTx = tx.sign(senderAccountKeyPair, {nonce});

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,8 +71,8 @@ const METABLOCKCHAIN_TYPES = {
   "Hash": "H256",
   "Signature": "H512",
   "TokenDetails": {
-    "token_name": "Bytes",
-    "currency_code": "Bytes",
+    "token_name": "Vec<u8>",
+    "currency_code": "Vec<u8>",
     "decimal": "u8",
     "block_number": "BlockNumber"
   },


### PR DESCRIPTION
This PR will fix the erroneous zero transfer of token when a user tries to transfer the amount less than the minimum supported by the token.  For eg: if there is a token with decimal support of 2, the lowest value user can transfer is 0.01. If a user tries to transfer 0.001, this fix will throw an error otherwise it will be normalised to 0 & a transaction of 0 will take place, which is unintended.